### PR TITLE
Implement TFT wager system with Top 4/Bottom 4 betting

### DIFF
--- a/api/proto/events/tft_events.proto
+++ b/api/proto/events/tft_events.proto
@@ -1,0 +1,43 @@
+syntax = "proto3";
+package gambler.events;
+
+option go_package = "gambler/api/gen/go/events";
+
+import "google/protobuf/timestamp.proto";
+
+// TFT-specific game status enum
+enum TFTGameStatus {
+  TFT_GAME_STATUS_NOT_IN_GAME = 0;     // Not currently playing (default)
+  TFT_GAME_STATUS_IN_GAME = 1;         // Currently in a TFT match
+}
+
+// TFT queue types enum
+enum TFTQueueType {
+  TFT_QUEUE_TYPE_UNKNOWN = 0;          // Unknown queue type
+  TFT_QUEUE_TYPE_RANKED_TFT = 1;       // Ranked Teamfight Tactics games
+  TFT_QUEUE_TYPE_RANKED_TFT_DOUBLE_UP = 2;  // Ranked Teamfight Tactics (Double Up Workshop) games
+  TFT_QUEUE_TYPE_RANKED_TFT_TURBO = 3;      // Ranked Teamfight Tactics (Hyper Roll) games
+}
+
+// Events emitted from tft-tracker
+message TFTGameStateChanged {
+  string game_name = 1;                // Summoner game name (e.g., "Faker")
+  string tag_line = 2;                 // Riot ID tag line (e.g., "KR1")
+  
+  TFTGameStatus previous_status = 3;   // Previous game status
+  TFTGameStatus current_status = 4;    // Current game status
+  
+  // Game context
+  string game_id = 5;                  // Riot game ID
+  TFTQueueType queue_type = 6;         // Type of TFT game
+  
+  // Game metadata (populated when transitioning out of IN_GAME)
+  optional TFTGameResult game_result = 7; // TFT-specific game result
+  google.protobuf.Timestamp event_time = 8; // When this change occurred
+  
+}
+
+message TFTGameResult {
+  int32 placement = 1;                 // Final placement (1-8)
+  int32 duration_seconds = 2;          // Game duration
+}

--- a/discord-client/application/base_house_wager_handler.go
+++ b/discord-client/application/base_house_wager_handler.go
@@ -1,0 +1,387 @@
+package application
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"gambler/discord-client/application/dto"
+	"gambler/discord-client/domain/entities"
+	"gambler/discord-client/domain/interfaces"
+	"gambler/discord-client/domain/services"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// BaseHouseWagerHandler provides common functionality for house wager systems
+type BaseHouseWagerHandler struct {
+	uowFactory    UnitOfWorkFactory
+	discordPoster DiscordPoster
+}
+
+// NewBaseHouseWagerHandler creates a new base house wager handler
+func NewBaseHouseWagerHandler(
+	uowFactory UnitOfWorkFactory,
+	discordPoster DiscordPoster,
+) *BaseHouseWagerHandler {
+	return &BaseHouseWagerHandler{
+		uowFactory:    uowFactory,
+		discordPoster: discordPoster,
+	}
+}
+
+// WagerCreationConfig holds configuration for creating a house wager
+type WagerCreationConfig struct {
+	ExternalSystem      entities.ExternalSystem
+	GameID              string
+	SummonerName        string
+	TagLine             string
+	Condition           string
+	Options             []string
+	OddsMultipliers     []float64
+	VotingPeriodMinutes int
+	ChannelIDGetter     func(*entities.GuildSettings) *int64
+	ChannelName         string // For error messages (e.g., "lol-channel", "tft-channel")
+}
+
+// CreateHouseWagerForGuild creates a house wager for a specific guild using the provided configuration
+func (h *BaseHouseWagerHandler) CreateHouseWagerForGuild(
+	ctx context.Context,
+	guild *entities.GuildSummonerWatch,
+	config WagerCreationConfig,
+) error {
+	// Create UoW for this guild
+	uow := h.uowFactory.CreateForGuild(guild.GuildID)
+	if err := uow.Begin(ctx); err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err := recover(); err != nil {
+			uow.Rollback()
+			panic(err)
+		}
+	}()
+
+	// Get guild settings for channel info
+	guildSettings, err := uow.GuildSettingsRepository().GetOrCreateGuildSettings(ctx, guild.GuildID)
+	if err != nil {
+		uow.Rollback()
+		return fmt.Errorf("failed to get guild settings: %w", err)
+	}
+
+	// Create group wager service
+	groupWagerService := services.NewGroupWagerService(
+		uow.GroupWagerRepository(),
+		uow.UserRepository(),
+		uow.BalanceHistoryRepository(),
+		uow.EventBus(),
+	)
+
+	// Use nil for system-created house wagers (no specific creator)
+	wagerDetail, err := groupWagerService.CreateGroupWager(
+		ctx,
+		nil,
+		config.Condition,
+		config.Options,
+		config.VotingPeriodMinutes,
+		0, // Message ID will be set after posting
+		0, // Channel ID will be set after posting
+		entities.GroupWagerTypeHouse,
+		config.OddsMultipliers,
+	)
+	if err != nil {
+		uow.Rollback()
+		return fmt.Errorf("failed to create group wager: %w", err)
+	}
+
+	// Set the external reference for this game
+	wagerDetail.Wager.SetExternalReference(config.ExternalSystem, config.GameID)
+
+	log.WithFields(log.Fields{
+		"guild":          guild.GuildID,
+		"wagerID":        wagerDetail.Wager.ID,
+		"gameID":         config.GameID,
+		"externalSystem": config.ExternalSystem,
+	}).Debug("Setting external reference for house wager")
+
+	// Update the wager with the external reference
+	if err := uow.GroupWagerRepository().Update(ctx, wagerDetail.Wager); err != nil {
+		uow.Rollback()
+		return fmt.Errorf("failed to update wager with external reference: %w", err)
+	}
+
+	// Build DTO for Discord posting
+	channelID := int64(0)
+	channelIDPtr := config.ChannelIDGetter(guildSettings)
+	if channelIDPtr != nil {
+		channelID = *channelIDPtr
+	} else {
+		return fmt.Errorf("failed to create group wager: %s is not set for guild %d", config.ChannelName, guild.GuildID)
+	}
+
+	// Build DTO using the helper function
+	postDTO := h.BuildHouseWagerDTO(wagerDetail)
+	// Override the channel ID since it might not be set in the wager yet
+	postDTO.ChannelID = channelID
+	// Ensure guild ID is set correctly (in case it's not set in the wager)
+	postDTO.GuildID = guild.GuildID
+
+	// Post to Discord
+	postResult, err := h.discordPoster.PostHouseWager(ctx, postDTO)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"guild":   guild.GuildID,
+			"wagerID": wagerDetail.Wager.ID,
+			"error":   err,
+		}).Error("Failed to post house wager to Discord")
+		// Don't return error - wager is created, just not posted
+	} else {
+		// Update the wager with messageID and channelID
+		wagerDetail.Wager.MessageID = postResult.MessageID
+		wagerDetail.Wager.ChannelID = postResult.ChannelID
+		if err := uow.GroupWagerRepository().Update(ctx, wagerDetail.Wager); err != nil {
+			log.WithFields(log.Fields{
+				"guild":     guild.GuildID,
+				"wagerID":   wagerDetail.Wager.ID,
+				"messageID": postResult.MessageID,
+				"channelID": postResult.ChannelID,
+				"error":     err,
+			}).Error("Failed to update wager with message info")
+		}
+	}
+
+	// Commit the transaction
+	if err := uow.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	log.WithFields(log.Fields{
+		"guild":    guild.GuildID,
+		"wagerID":  wagerDetail.Wager.ID,
+		"summoner": fmt.Sprintf("%s#%s", config.SummonerName, config.TagLine),
+	}).Info("Created house wager for game start")
+
+	return nil
+}
+
+// WagerResolutionConfig holds configuration for resolving a house wager
+type WagerResolutionConfig struct {
+	ExternalSystem        entities.ExternalSystem
+	WinnerSelector        func([]entities.GroupWagerOption, interface{}) int64
+	GameResult            interface{}
+	CancellationThreshold *int32 // nil means no cancellation logic
+}
+
+// ResolveHouseWager resolves a specific house wager using the provided configuration
+func (h *BaseHouseWagerHandler) ResolveHouseWager(
+	ctx context.Context,
+	guildID, wagerID int64,
+	config WagerResolutionConfig,
+) error {
+	// Create UoW for this guild
+	uow := h.uowFactory.CreateForGuild(guildID)
+	if err := uow.Begin(ctx); err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err := recover(); err != nil {
+			uow.Rollback()
+			panic(err)
+		}
+	}()
+
+	// Get the wager details
+	wagerDetail, err := uow.GroupWagerRepository().GetDetailByID(ctx, wagerID)
+	if err != nil {
+		uow.Rollback()
+		return fmt.Errorf("failed to get wager detail: %w", err)
+	}
+
+	if wagerDetail == nil || wagerDetail.Wager == nil {
+		uow.Rollback()
+		return fmt.Errorf("wager not found")
+	}
+
+	// Create group wager service once
+	groupWagerService := services.NewGroupWagerService(
+		uow.GroupWagerRepository(),
+		uow.UserRepository(),
+		uow.BalanceHistoryRepository(),
+		uow.EventBus(),
+	)
+
+	// Check for cancellation conditions if threshold is provided
+	if config.CancellationThreshold != nil {
+		if durationResult, ok := config.GameResult.(dto.GameEndedDTO); ok {
+			if durationResult.DurationSeconds < *config.CancellationThreshold {
+				return h.cancelWager(ctx, uow, groupWagerService, wagerDetail, guildID, wagerID, durationResult.DurationSeconds)
+			}
+		}
+	}
+
+	// Determine winning option using the provided selector
+	// Convert []*entities.GroupWagerOption to []entities.GroupWagerOption
+	options := make([]entities.GroupWagerOption, len(wagerDetail.Options))
+	for i, opt := range wagerDetail.Options {
+		if opt != nil {
+			options[i] = *opt
+		}
+	}
+	winningOptionID := config.WinnerSelector(options, config.GameResult)
+
+	if winningOptionID == 0 {
+		uow.Rollback()
+		return fmt.Errorf("could not determine winning option")
+	}
+
+	log.WithFields(log.Fields{
+		"guild":           guildID,
+		"wagerID":         wagerID,
+		"wagerState":      wagerDetail.Wager.State,
+		"participants":    len(wagerDetail.Participants),
+		"winningOptionID": winningOptionID,
+	}).Debug("Attempting to resolve house wager")
+
+	// For house wagers, use nil to indicate system resolution (no human resolver)
+	result, err := groupWagerService.ResolveGroupWager(ctx, wagerID, nil, winningOptionID)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"guild":   guildID,
+			"wagerID": wagerID,
+			"error":   err,
+		}).Error("Failed to resolve group wager in service")
+		uow.Rollback()
+		return fmt.Errorf("failed to resolve group wager: %w", err)
+	}
+
+	// Commit the transaction
+	if err := uow.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	log.WithFields(log.Fields{
+		"guild":         guildID,
+		"wagerID":       wagerID,
+		"winningOption": winningOptionID,
+		"totalPot":      result.TotalPot,
+		"winnersCount":  len(result.Winners),
+	}).Info("Resolved house wager")
+
+	return nil
+}
+
+// cancelWager handles the cancellation logic for short games
+func (h *BaseHouseWagerHandler) cancelWager(
+	ctx context.Context,
+	uow UnitOfWork,
+	groupWagerService interfaces.GroupWagerService,
+	wagerDetail *entities.GroupWagerDetail,
+	guildID, wagerID int64,
+	durationSeconds int32,
+) error {
+	log.WithFields(log.Fields{
+		"guild":           guildID,
+		"wagerID":         wagerID,
+		"durationSeconds": durationSeconds,
+	}).Info("Game ended with short duration (forfeit/remake), cancelling wager and refunding participants")
+
+	// Cancel the wager (nil indicates system cancellation)
+	if err := groupWagerService.CancelGroupWager(ctx, wagerID, nil); err != nil {
+		log.WithFields(log.Fields{
+			"guild":   guildID,
+			"wagerID": wagerID,
+			"error":   err,
+		}).Error("Failed to cancel group wager")
+		uow.Rollback()
+		return fmt.Errorf("failed to cancel group wager: %w", err)
+	}
+
+	// Store message info before committing
+	messageID := wagerDetail.Wager.MessageID
+	channelID := wagerDetail.Wager.ChannelID
+
+	// Commit the transaction
+	if err := uow.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	log.WithFields(log.Fields{
+		"guild":   guildID,
+		"wagerID": wagerID,
+	}).Info("Successfully cancelled house wager and refunded participants")
+
+	// Update the Discord message to show cancelled state
+	if messageID != 0 && channelID != 0 {
+		// Update the state to cancelled since we know it was just cancelled
+		wagerDetail.Wager.State = entities.GroupWagerStateCancelled
+
+		// Build DTO for Discord update using the helper function
+		updateDTO := h.BuildHouseWagerDTO(wagerDetail)
+
+		// Update the Discord message
+		if err := h.discordPoster.UpdateHouseWager(ctx, messageID, channelID, updateDTO); err != nil {
+			log.WithFields(log.Fields{
+				"guild":     guildID,
+				"wagerID":   wagerID,
+				"messageID": messageID,
+				"channelID": channelID,
+				"error":     err,
+			}).Error("Failed to update Discord message for cancelled house wager")
+		} else {
+			log.WithFields(log.Fields{
+				"guild":     guildID,
+				"wagerID":   wagerID,
+				"messageID": messageID,
+			}).Info("Successfully updated Discord message for cancelled house wager")
+		}
+	}
+
+	return nil
+}
+
+// BuildHouseWagerDTO builds a HouseWagerPostDTO from a GroupWagerDetail
+func (h *BaseHouseWagerHandler) BuildHouseWagerDTO(detail *entities.GroupWagerDetail) dto.HouseWagerPostDTO {
+	// Parse the condition to extract title and description
+	parts := strings.SplitN(detail.Wager.Condition, "\n", 2)
+	title := parts[0]
+	description := ""
+	if len(parts) > 1 {
+		description = parts[1]
+	}
+
+	// Build DTO
+	result := dto.HouseWagerPostDTO{
+		GuildID:      detail.Wager.GuildID,
+		ChannelID:    detail.Wager.ChannelID,
+		WagerID:      detail.Wager.ID,
+		Title:        title,
+		Description:  description,
+		State:        string(detail.Wager.State),
+		Options:      make([]dto.WagerOptionDTO, len(detail.Options)),
+		VotingEndsAt: detail.Wager.VotingEndsAt,
+		Participants: make([]dto.ParticipantDTO, len(detail.Participants)),
+		TotalPot:     detail.Wager.TotalPot,
+	}
+
+	// Convert options
+	for i, opt := range detail.Options {
+		result.Options[i] = dto.WagerOptionDTO{
+			ID:          opt.ID,
+			Text:        opt.OptionText,
+			Order:       opt.OptionOrder,
+			Multiplier:  opt.OddsMultiplier,
+			TotalAmount: opt.TotalAmount,
+		}
+	}
+
+	// Convert participants
+	for i, participant := range detail.Participants {
+		result.Participants[i] = dto.ParticipantDTO{
+			DiscordID: participant.DiscordID,
+			OptionID:  participant.OptionID,
+			Amount:    participant.Amount,
+		}
+	}
+
+	return result
+}

--- a/discord-client/application/base_house_wager_handler_test.go
+++ b/discord-client/application/base_house_wager_handler_test.go
@@ -1,0 +1,495 @@
+package application
+
+import (
+	"testing"
+	"time"
+
+	"gambler/discord-client/application/dto"
+	"gambler/discord-client/domain/entities"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBaseHouseWagerHandler_BuildHouseWagerDTO(t *testing.T) {
+	t.Parallel()
+	
+	// Create handler for testing
+	handler := NewBaseHouseWagerHandler(nil, nil)
+
+	tests := []struct {
+		name     string
+		detail   *entities.GroupWagerDetail
+		expected dto.HouseWagerPostDTO
+	}{
+		{
+			name: "basic wager with title only",
+			detail: &entities.GroupWagerDetail{
+				Wager: &entities.GroupWager{
+					ID:           123,
+					GuildID:      12345,
+					ChannelID:    999,
+					Condition:    "TestPlayer - **TFT Match**",
+					State:        entities.GroupWagerStateActive,
+					TotalPot:     500,
+					VotingEndsAt: func() *time.Time { t := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC); return &t }(),
+				},
+				Options: []*entities.GroupWagerOption{
+					{
+						ID:             1,
+						OptionText:     "Top 4",
+						OptionOrder:    1,
+						OddsMultiplier: 2.0,
+						TotalAmount:    250,
+					},
+					{
+						ID:             2,
+						OptionText:     "Bottom 4",
+						OptionOrder:    2,
+						OddsMultiplier: 2.0,
+						TotalAmount:    250,
+					},
+				},
+				Participants: []*entities.GroupWagerParticipant{
+					{
+						DiscordID: 111111111111111111,
+						OptionID:  1,
+						Amount:    100,
+					},
+					{
+						DiscordID: 222222222222222222,
+						OptionID:  2,
+						Amount:    150,
+					},
+				},
+			},
+			expected: dto.HouseWagerPostDTO{
+				GuildID:      12345,
+				ChannelID:    999,
+				WagerID:      123,
+				Title:        "TestPlayer - **TFT Match**",
+				Description:  "",
+				State:        "active",
+				TotalPot:     500,
+				VotingEndsAt: func() *time.Time { t := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC); return &t }(),
+				Options: []dto.WagerOptionDTO{
+					{
+						ID:          1,
+						Text:        "Top 4",
+						Order:       1,
+						Multiplier:  2.0,
+						TotalAmount: 250,
+					},
+					{
+						ID:          2,
+						Text:        "Bottom 4",
+						Order:       2,
+						Multiplier:  2.0,
+						TotalAmount: 250,
+					},
+				},
+				Participants: []dto.ParticipantDTO{
+					{
+						DiscordID: 111111111111111111,
+						OptionID:  1,
+						Amount:    100,
+					},
+					{
+						DiscordID: 222222222222222222,
+						OptionID:  2,
+						Amount:    150,
+					},
+				},
+			},
+		},
+		{
+			name: "wager with title and description",
+			detail: &entities.GroupWagerDetail{
+				Wager: &entities.GroupWager{
+					ID:           456,
+					GuildID:      54321,
+					ChannelID:    888,
+					Condition:    "ProPlayer - **LoL Match**\nRanked Solo Queue - Diamond+",
+					State:        entities.GroupWagerStateResolved,
+					TotalPot:     1000,
+					VotingEndsAt: func() *time.Time { t := time.Date(2024, 2, 20, 18, 30, 0, 0, time.UTC); return &t }(),
+				},
+				Options: []*entities.GroupWagerOption{
+					{
+						ID:             1,
+						OptionText:     "Win",
+						OptionOrder:    1,
+						OddsMultiplier: 1.8,
+						TotalAmount:    600,
+					},
+					{
+						ID:             2,
+						OptionText:     "Loss",
+						OptionOrder:    2,
+						OddsMultiplier: 2.2,
+						TotalAmount:    400,
+					},
+				},
+				Participants: []*entities.GroupWagerParticipant{
+					{
+						DiscordID: 333333333333333333,
+						OptionID:  1,
+						Amount:    200,
+					},
+					{
+						DiscordID: 444444444444444444,
+						OptionID:  1,
+						Amount:    400,
+					},
+					{
+						DiscordID: 555555555555555555,
+						OptionID:  2,
+						Amount:    400,
+					},
+				},
+			},
+			expected: dto.HouseWagerPostDTO{
+				GuildID:      54321,
+				ChannelID:    888,
+				WagerID:      456,
+				Title:        "ProPlayer - **LoL Match**",
+				Description:  "Ranked Solo Queue - Diamond+",
+				State:        "resolved",
+				TotalPot:     1000,
+				VotingEndsAt: func() *time.Time { t := time.Date(2024, 2, 20, 18, 30, 0, 0, time.UTC); return &t }(),
+				Options: []dto.WagerOptionDTO{
+					{
+						ID:          1,
+						Text:        "Win",
+						Order:       1,
+						Multiplier:  1.8,
+						TotalAmount: 600,
+					},
+					{
+						ID:          2,
+						Text:        "Loss",
+						Order:       2,
+						Multiplier:  2.2,
+						TotalAmount: 400,
+					},
+				},
+				Participants: []dto.ParticipantDTO{
+					{
+						DiscordID: 333333333333333333,
+						OptionID:  1,
+						Amount:    200,
+					},
+					{
+						DiscordID: 444444444444444444,
+						OptionID:  1,
+						Amount:    400,
+					},
+					{
+						DiscordID: 555555555555555555,
+						OptionID:  2,
+						Amount:    400,
+					},
+				},
+			},
+		},
+		{
+			name: "cancelled wager with no participants",
+			detail: &entities.GroupWagerDetail{
+				Wager: &entities.GroupWager{
+					ID:           789,
+					GuildID:      99999,
+					ChannelID:    777,
+					Condition:    "ShortGamePlayer - **TFT Match**",
+					State:        entities.GroupWagerStateCancelled,
+					TotalPot:     0,
+					VotingEndsAt: func() *time.Time { t := time.Date(2024, 3, 10, 14, 0, 0, 0, time.UTC); return &t }(),
+				},
+				Options: []*entities.GroupWagerOption{
+					{
+						ID:             1,
+						OptionText:     "Top 4",
+						OptionOrder:    1,
+						OddsMultiplier: 2.0,
+						TotalAmount:    0,
+					},
+					{
+						ID:             2,
+						OptionText:     "Bottom 4",
+						OptionOrder:    2,
+						OddsMultiplier: 2.0,
+						TotalAmount:    0,
+					},
+				},
+				Participants: []*entities.GroupWagerParticipant{},
+			},
+			expected: dto.HouseWagerPostDTO{
+				GuildID:      99999,
+				ChannelID:    777,
+				WagerID:      789,
+				Title:        "ShortGamePlayer - **TFT Match**",
+				Description:  "",
+				State:        "cancelled",
+				TotalPot:     0,
+				VotingEndsAt: func() *time.Time { t := time.Date(2024, 3, 10, 14, 0, 0, 0, time.UTC); return &t }(),
+				Options: []dto.WagerOptionDTO{
+					{
+						ID:          1,
+						Text:        "Top 4",
+						Order:       1,
+						Multiplier:  2.0,
+						TotalAmount: 0,
+					},
+					{
+						ID:          2,
+						Text:        "Bottom 4",
+						Order:       2,
+						Multiplier:  2.0,
+						TotalAmount: 0,
+					},
+				},
+				Participants: []dto.ParticipantDTO{},
+			},
+		},
+		{
+			name: "wager with multiline description",
+			detail: &entities.GroupWagerDetail{
+				Wager: &entities.GroupWager{
+					ID:           999,
+					GuildID:      11111,
+					ChannelID:    666,
+					Condition:    "ComplexPlayer - **TFT Match**\nSet 12 Ranked\nChallenger MMR\nExpected 20+ minute game",
+					State:        entities.GroupWagerStateActive,
+					TotalPot:     2500,
+					VotingEndsAt: func() *time.Time { t := time.Date(2024, 4, 5, 20, 15, 0, 0, time.UTC); return &t }(),
+				},
+				Options: []*entities.GroupWagerOption{
+					{
+						ID:             1,
+						OptionText:     "Top 4",
+						OptionOrder:    1,
+						OddsMultiplier: 1.9,
+						TotalAmount:    1300,
+					},
+					{
+						ID:             2,
+						OptionText:     "Bottom 4",
+						OptionOrder:    2,
+						OddsMultiplier: 2.1,
+						TotalAmount:    1200,
+					},
+				},
+				Participants: []*entities.GroupWagerParticipant{
+					{
+						DiscordID: 777777777777777777,
+						OptionID:  1,
+						Amount:    500,
+					},
+					{
+						DiscordID: 888888888888888888,
+						OptionID:  1,
+						Amount:    800,
+					},
+					{
+						DiscordID: 999999999999999999,
+						OptionID:  2,
+						Amount:    1200,
+					},
+				},
+			},
+			expected: dto.HouseWagerPostDTO{
+				GuildID:      11111,
+				ChannelID:    666,
+				WagerID:      999,
+				Title:        "ComplexPlayer - **TFT Match**",
+				Description:  "Set 12 Ranked\nChallenger MMR\nExpected 20+ minute game",
+				State:        "active",
+				TotalPot:     2500,
+				VotingEndsAt: func() *time.Time { t := time.Date(2024, 4, 5, 20, 15, 0, 0, time.UTC); return &t }(),
+				Options: []dto.WagerOptionDTO{
+					{
+						ID:          1,
+						Text:        "Top 4",
+						Order:       1,
+						Multiplier:  1.9,
+						TotalAmount: 1300,
+					},
+					{
+						ID:          2,
+						Text:        "Bottom 4",
+						Order:       2,
+						Multiplier:  2.1,
+						TotalAmount: 1200,
+					},
+				},
+				Participants: []dto.ParticipantDTO{
+					{
+						DiscordID: 777777777777777777,
+						OptionID:  1,
+						Amount:    500,
+					},
+					{
+						DiscordID: 888888888888888888,
+						OptionID:  1,
+						Amount:    800,
+					},
+					{
+						DiscordID: 999999999999999999,
+						OptionID:  2,
+						Amount:    1200,
+					},
+				},
+			},
+		},
+		{
+			name: "empty condition handling",
+			detail: &entities.GroupWagerDetail{
+				Wager: &entities.GroupWager{
+					ID:           100,
+					GuildID:      22222,
+					ChannelID:    555,
+					Condition:    "",
+					State:        entities.GroupWagerStateActive,
+					TotalPot:     0,
+					VotingEndsAt: func() *time.Time { t := time.Date(2024, 5, 1, 10, 0, 0, 0, time.UTC); return &t }(),
+				},
+				Options:      []*entities.GroupWagerOption{},
+				Participants: []*entities.GroupWagerParticipant{},
+			},
+			expected: dto.HouseWagerPostDTO{
+				GuildID:      22222,
+				ChannelID:    555,
+				WagerID:      100,
+				Title:        "",
+				Description:  "",
+				State:        "active",
+				TotalPot:     0,
+				VotingEndsAt: func() *time.Time { t := time.Date(2024, 5, 1, 10, 0, 0, 0, time.UTC); return &t }(),
+				Options:      []dto.WagerOptionDTO{},
+				Participants: []dto.ParticipantDTO{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			
+			result := handler.BuildHouseWagerDTO(tt.detail)
+			
+			// Assert all fields match
+			assert.Equal(t, tt.expected.GuildID, result.GuildID)
+			assert.Equal(t, tt.expected.ChannelID, result.ChannelID)
+			assert.Equal(t, tt.expected.WagerID, result.WagerID)
+			assert.Equal(t, tt.expected.Title, result.Title)
+			assert.Equal(t, tt.expected.Description, result.Description)
+			assert.Equal(t, tt.expected.State, result.State)
+			assert.Equal(t, tt.expected.TotalPot, result.TotalPot)
+			assert.Equal(t, tt.expected.VotingEndsAt, result.VotingEndsAt)
+			
+			// Assert options match
+			assert.Len(t, result.Options, len(tt.expected.Options))
+			for i, expectedOption := range tt.expected.Options {
+				if i < len(result.Options) {
+					assert.Equal(t, expectedOption.ID, result.Options[i].ID)
+					assert.Equal(t, expectedOption.Text, result.Options[i].Text)
+					assert.Equal(t, expectedOption.Order, result.Options[i].Order)
+					assert.Equal(t, expectedOption.Multiplier, result.Options[i].Multiplier)
+					assert.Equal(t, expectedOption.TotalAmount, result.Options[i].TotalAmount)
+				}
+			}
+			
+			// Assert participants match
+			assert.Len(t, result.Participants, len(tt.expected.Participants))
+			for i, expectedParticipant := range tt.expected.Participants {
+				if i < len(result.Participants) {
+					assert.Equal(t, expectedParticipant.DiscordID, result.Participants[i].DiscordID)
+					assert.Equal(t, expectedParticipant.OptionID, result.Participants[i].OptionID)
+					assert.Equal(t, expectedParticipant.Amount, result.Participants[i].Amount)
+				}
+			}
+			
+			// Use overall struct comparison for final verification
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestBaseHouseWagerHandler_BuildHouseWagerDTO_ConditionParsing(t *testing.T) {
+	t.Parallel()
+	
+	handler := NewBaseHouseWagerHandler(nil, nil)
+
+	tests := []struct {
+		name              string
+		condition         string
+		expectedTitle     string
+		expectedDescription string
+	}{
+		{
+			name:              "title only",
+			condition:         "Player - **TFT Match**",
+			expectedTitle:     "Player - **TFT Match**",
+			expectedDescription: "",
+		},
+		{
+			name:              "title with single line description",
+			condition:         "Player - **TFT Match**\nRanked Game",
+			expectedTitle:     "Player - **TFT Match**",
+			expectedDescription: "Ranked Game",
+		},
+		{
+			name:              "title with multiline description",
+			condition:         "Player - **TFT Match**\nSet 12 Ranked\nChallenger MMR",
+			expectedTitle:     "Player - **TFT Match**",
+			expectedDescription: "Set 12 Ranked\nChallenger MMR",
+		},
+		{
+			name:              "empty condition",
+			condition:         "",
+			expectedTitle:     "",
+			expectedDescription: "",
+		},
+		{
+			name:              "only newline",
+			condition:         "\n",
+			expectedTitle:     "",
+			expectedDescription: "",
+		},
+		{
+			name:              "newline at start",
+			condition:         "\nDescription only",
+			expectedTitle:     "",
+			expectedDescription: "Description only",
+		},
+		{
+			name:              "multiple consecutive newlines",
+			condition:         "Title\n\n\nDescription with gaps",
+			expectedTitle:     "Title",
+			expectedDescription: "\n\nDescription with gaps",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			
+			detail := &entities.GroupWagerDetail{
+				Wager: &entities.GroupWager{
+					ID:           1,
+					GuildID:      1,
+					ChannelID:    1,
+					Condition:    tt.condition,
+					State:        entities.GroupWagerStateActive,
+					TotalPot:     0,
+					VotingEndsAt: func() *time.Time { t := time.Now(); return &t }(),
+				},
+				Options:      []*entities.GroupWagerOption{},
+				Participants: []*entities.GroupWagerParticipant{},
+			}
+			
+			result := handler.BuildHouseWagerDTO(detail)
+			
+			assert.Equal(t, tt.expectedTitle, result.Title)
+			assert.Equal(t, tt.expectedDescription, result.Description)
+		})
+	}
+}

--- a/discord-client/application/dto/game_events.go
+++ b/discord-client/application/dto/game_events.go
@@ -22,3 +22,23 @@ type GameEndedDTO struct {
 	ChampionPlayed  string
 	EventTime       time.Time
 }
+
+// TFTGameStartedDTO represents a TFT game that has started
+type TFTGameStartedDTO struct {
+	GameID       string
+	SummonerName string
+	TagLine      string
+	QueueType    string
+	EventTime    time.Time
+}
+
+// TFTGameEndedDTO represents a TFT game that has ended
+type TFTGameEndedDTO struct {
+	GameID          string
+	SummonerName    string
+	TagLine         string
+	Placement       int32 // 1-8 placement
+	DurationSeconds int32
+	QueueType       string
+	EventTime       time.Time
+}

--- a/discord-client/application/interfaces.go
+++ b/discord-client/application/interfaces.go
@@ -47,6 +47,16 @@ type LoLEventHandler interface {
 	HandleGameEnded(ctx context.Context, gameEnded dto.GameEndedDTO) error
 }
 
+// TFTEventHandler defines the interface for handling TFT game events
+// This interface receives domain DTOs, not raw bytes
+type TFTEventHandler interface {
+	// HandleGameStarted processes a TFT game started event
+	HandleGameStarted(ctx context.Context, gameStarted dto.TFTGameStartedDTO) error
+
+	// HandleGameEnded processes a TFT game ended event
+	HandleGameEnded(ctx context.Context, gameEnded dto.TFTGameEndedDTO) error
+}
+
 // GuildDiscoveryService discovers guilds and their channel configurations
 type GuildDiscoveryService interface {
 	// GetGuildsWithPrimaryChannel returns all guilds that have a primary channel configured

--- a/discord-client/application/tft_handler_integration_test.go
+++ b/discord-client/application/tft_handler_integration_test.go
@@ -1,0 +1,722 @@
+package application_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"gambler/discord-client/application"
+	"gambler/discord-client/application/dto"
+	"gambler/discord-client/config"
+	"gambler/discord-client/domain/entities"
+	"gambler/discord-client/infrastructure"
+	"gambler/discord-client/repository/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTFTHandler_EndToEndFlow(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// Set up test config
+	config.SetTestConfig(config.NewTestConfig())
+	defer config.ResetConfig()
+
+	// Setup test database
+	testDB := testutil.SetupTestDatabase(t)
+	defer testDB.Cleanup(t)
+
+	// Create no-op event publisher for integration tests
+	noopPublisher := infrastructure.NewNoopEventPublisher()
+
+	// Create UoW factory
+	uowFactory := infrastructure.NewUnitOfWorkFactory(testDB.DB, noopPublisher)
+
+	// Setup test data
+	ctx := context.Background()
+	guildID := int64(12345)
+	summonerName := "TFTPlayer"
+	tagLine := "NA1"
+	gameID := "tft-game-123"
+
+	// Setup guild and summoner watch with TFT channel
+	setupTFTTestData(t, ctx, uowFactory, guildID, summonerName, tagLine)
+
+	// Create mock Discord poster
+	mockPoster := &application.MockDiscordPoster{}
+
+	// Create TFT handler
+	handler := application.NewTFTHandler(uowFactory, mockPoster)
+
+	t.Run("Game Start Creates TFT House Wager", func(t *testing.T) {
+		// TFT game start event
+		gameStarted := dto.TFTGameStartedDTO{
+			SummonerName: summonerName,
+			TagLine:      tagLine,
+			GameID:       gameID,
+			QueueType:    "RANKED_TFT",
+		}
+
+		// Handle game start
+		err := handler.HandleGameStarted(ctx, gameStarted)
+		require.NoError(t, err)
+
+		// Verify Discord post was made
+		assert.Len(t, mockPoster.Posts, 1)
+		post := mockPoster.Posts[0]
+		assert.Equal(t, guildID, post.GuildID)
+		assert.Contains(t, post.Title, summonerName)
+		assert.Contains(t, post.Title, "TFT Match")
+		assert.Len(t, post.Options, 2) // Top 4/Bottom 4 options
+
+		// Verify TFT-specific options
+		assert.Equal(t, "Top 4", post.Options[0].Text)
+		assert.Equal(t, "Bottom 4", post.Options[1].Text)
+		assert.Equal(t, float64(2.0), post.Options[0].Multiplier)
+		assert.Equal(t, float64(2.0), post.Options[1].Multiplier)
+
+		// Verify wager was created in database
+		uow := uowFactory.CreateForGuild(guildID)
+		require.NoError(t, uow.Begin(ctx))
+		defer uow.Rollback()
+
+		externalRef := entities.ExternalReference{
+			System: entities.SystemTFT,
+			ID:     gameID,
+		}
+
+		wager, err := uow.GroupWagerRepository().GetByExternalReference(ctx, externalRef)
+		require.NoError(t, err)
+		require.NotNil(t, wager)
+
+		assert.Equal(t, entities.GroupWagerTypeHouse, wager.WagerType)
+		assert.Equal(t, entities.GroupWagerStateActive, wager.State)
+		assert.Equal(t, guildID, wager.GuildID)
+		assert.NotNil(t, wager.ExternalRef)
+		assert.Equal(t, gameID, wager.ExternalRef.ID)
+		assert.Equal(t, entities.SystemTFT, wager.ExternalRef.System)
+	})
+
+	t.Run("Game End Resolves TFT House Wager - Top 4", func(t *testing.T) {
+		// TFT game end event - player gets 3rd place (Top 4)
+		gameEnded := dto.TFTGameEndedDTO{
+			SummonerName:    summonerName,
+			TagLine:         tagLine,
+			GameID:          gameID,
+			Placement:       3, // Top 4
+			DurationSeconds: 1800, // 30 minutes
+			QueueType:       "RANKED_TFT",
+		}
+
+		// Handle game end
+		err := handler.HandleGameEnded(ctx, gameEnded)
+		require.NoError(t, err)
+
+		// Verify wager was resolved
+		uow := uowFactory.CreateForGuild(guildID)
+		require.NoError(t, uow.Begin(ctx))
+		defer uow.Rollback()
+
+		externalRef := entities.ExternalReference{
+			System: entities.SystemTFT,
+			ID:     gameID,
+		}
+
+		wager, err := uow.GroupWagerRepository().GetByExternalReference(ctx, externalRef)
+		require.NoError(t, err)
+		require.NotNil(t, wager)
+
+		assert.Equal(t, entities.GroupWagerStateResolved, wager.State)
+		assert.NotNil(t, wager.WinningOptionID)
+
+		// Verify the correct option won (Top 4 option)
+		detail, err := uow.GroupWagerRepository().GetDetailByID(ctx, wager.ID)
+		require.NoError(t, err)
+		require.NotNil(t, detail)
+
+		var winOption *entities.GroupWagerOption
+		for _, opt := range detail.Options {
+			if opt.ID == *wager.WinningOptionID {
+				winOption = opt
+				break
+			}
+		}
+		require.NotNil(t, winOption)
+		assert.Equal(t, "Top 4", winOption.OptionText)
+	})
+}
+
+func TestTFTHandler_EndToEndFlow_Bottom4(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// Set up test config
+	config.SetTestConfig(config.NewTestConfig())
+	defer config.ResetConfig()
+
+	// Setup test database
+	testDB := testutil.SetupTestDatabase(t)
+	defer testDB.Cleanup(t)
+
+	// Create no-op event publisher for integration tests
+	noopPublisher := infrastructure.NewNoopEventPublisher()
+
+	// Create UoW factory
+	uowFactory := infrastructure.NewUnitOfWorkFactory(testDB.DB, noopPublisher)
+
+	// Setup test data
+	ctx := context.Background()
+	guildID := int64(54321)
+	summonerName := "TFTPlayer2"
+	tagLine := "EUW1"
+	gameID := "tft-game-456"
+
+	// Setup guild and summoner watch
+	setupTFTTestData(t, ctx, uowFactory, guildID, summonerName, tagLine)
+
+	// Create mock Discord poster
+	mockPoster := &application.MockDiscordPoster{}
+
+	// Create TFT handler
+	handler := application.NewTFTHandler(uowFactory, mockPoster)
+
+	// Game start
+	gameStarted := dto.TFTGameStartedDTO{
+		SummonerName: summonerName,
+		TagLine:      tagLine,
+		GameID:       gameID,
+		QueueType:    "RANKED_TFT",
+	}
+
+	err := handler.HandleGameStarted(ctx, gameStarted)
+	require.NoError(t, err)
+
+	// Game end - player gets 6th place (Bottom 4)
+	gameEnded := dto.TFTGameEndedDTO{
+		SummonerName:    summonerName,
+		TagLine:         tagLine,
+		GameID:          gameID,
+		Placement:       6, // Bottom 4
+		DurationSeconds: 1200, // 20 minutes
+		QueueType:       "RANKED_TFT",
+	}
+
+	err = handler.HandleGameEnded(ctx, gameEnded)
+	require.NoError(t, err)
+
+	// Verify wager was resolved with Bottom 4 option
+	uow := uowFactory.CreateForGuild(guildID)
+	require.NoError(t, uow.Begin(ctx))
+	defer uow.Rollback()
+
+	externalRef := entities.ExternalReference{
+		System: entities.SystemTFT,
+		ID:     gameID,
+	}
+
+	wager, err := uow.GroupWagerRepository().GetByExternalReference(ctx, externalRef)
+	require.NoError(t, err)
+	require.NotNil(t, wager)
+
+	assert.Equal(t, entities.GroupWagerStateResolved, wager.State)
+	assert.NotNil(t, wager.WinningOptionID)
+
+	// Verify the correct option won (Bottom 4 option)
+	detail, err := uow.GroupWagerRepository().GetDetailByID(ctx, wager.ID)
+	require.NoError(t, err)
+	require.NotNil(t, detail)
+
+	var winOption *entities.GroupWagerOption
+	for _, opt := range detail.Options {
+		if opt.ID == *wager.WinningOptionID {
+			winOption = opt
+			break
+		}
+	}
+	require.NotNil(t, winOption)
+	assert.Equal(t, "Bottom 4", winOption.OptionText)
+}
+
+func TestTFTHandler_PlacementBoundaries(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	testCases := []struct {
+		name              string
+		placement         int32
+		expectedWinOption string
+	}{
+		{"1st place", 1, "Top 4"},
+		{"4th place exactly", 4, "Top 4"},
+		{"5th place", 5, "Bottom 4"},
+		{"8th place", 8, "Bottom 4"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Set up test config
+			config.SetTestConfig(config.NewTestConfig())
+			defer config.ResetConfig()
+
+			// Setup test database
+			testDB := testutil.SetupTestDatabase(t)
+			defer testDB.Cleanup(t)
+
+			// Create no-op event publisher for integration tests
+			noopPublisher := infrastructure.NewNoopEventPublisher()
+
+			// Create UoW factory
+			uowFactory := infrastructure.NewUnitOfWorkFactory(testDB.DB, noopPublisher)
+
+			// Setup test data
+			ctx := context.Background()
+			guildID := int64(77777 + int64(tc.placement)) // Unique guild per test
+			summonerName := "BoundaryPlayer"
+			tagLine := "TEST"
+			gameID := fmt.Sprintf("tft-boundary-%d", tc.placement)
+
+			// Setup guild and summoner watch
+			setupTFTTestData(t, ctx, uowFactory, guildID, summonerName, tagLine)
+
+			// Create mock Discord poster
+			mockPoster := &application.MockDiscordPoster{}
+
+			// Create TFT handler
+			handler := application.NewTFTHandler(uowFactory, mockPoster)
+
+			// Game start
+			gameStarted := dto.TFTGameStartedDTO{
+				SummonerName: summonerName,
+				TagLine:      tagLine,
+				GameID:       gameID,
+				QueueType:    "RANKED_TFT",
+			}
+
+			err := handler.HandleGameStarted(ctx, gameStarted)
+			require.NoError(t, err)
+
+			// Game end with specific placement
+			gameEnded := dto.TFTGameEndedDTO{
+				SummonerName:    summonerName,
+				TagLine:         tagLine,
+				GameID:          gameID,
+				Placement:       tc.placement,
+				DurationSeconds: 1500,
+				QueueType:       "RANKED_TFT",
+			}
+
+			err = handler.HandleGameEnded(ctx, gameEnded)
+			require.NoError(t, err)
+
+			// Verify correct winner selection
+			uow := uowFactory.CreateForGuild(guildID)
+			require.NoError(t, uow.Begin(ctx))
+			defer uow.Rollback()
+
+			externalRef := entities.ExternalReference{
+				System: entities.SystemTFT,
+				ID:     gameID,
+			}
+
+			wager, err := uow.GroupWagerRepository().GetByExternalReference(ctx, externalRef)
+			require.NoError(t, err)
+			require.NotNil(t, wager)
+
+			assert.Equal(t, entities.GroupWagerStateResolved, wager.State)
+			assert.NotNil(t, wager.WinningOptionID)
+
+			// Verify the correct option won
+			detail, err := uow.GroupWagerRepository().GetDetailByID(ctx, wager.ID)
+			require.NoError(t, err)
+			require.NotNil(t, detail)
+
+			var winOption *entities.GroupWagerOption
+			for _, opt := range detail.Options {
+				if opt.ID == *wager.WinningOptionID {
+					winOption = opt
+					break
+				}
+			}
+			require.NotNil(t, winOption)
+			assert.Equal(t, tc.expectedWinOption, winOption.OptionText)
+		})
+	}
+}
+
+func TestTFTHandler_NoCancellationLogic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// Set up test config
+	config.SetTestConfig(config.NewTestConfig())
+	defer config.ResetConfig()
+
+	// Setup test database
+	testDB := testutil.SetupTestDatabase(t)
+	defer testDB.Cleanup(t)
+
+	// Create no-op event publisher for integration tests
+	noopPublisher := infrastructure.NewNoopEventPublisher()
+
+	// Create UoW factory
+	uowFactory := infrastructure.NewUnitOfWorkFactory(testDB.DB, noopPublisher)
+
+	// Setup test data
+	ctx := context.Background()
+	guildID := int64(88888)
+	summonerName := "ShortGamePlayer"
+	tagLine := "NA1"
+	gameID := "tft-short-game"
+
+	// Setup guild and summoner watch
+	setupTFTTestData(t, ctx, uowFactory, guildID, summonerName, tagLine)
+
+	// Create mock Discord poster
+	mockPoster := &application.MockDiscordPoster{}
+
+	// Create TFT handler
+	handler := application.NewTFTHandler(uowFactory, mockPoster)
+
+	// Game start
+	gameStarted := dto.TFTGameStartedDTO{
+		SummonerName: summonerName,
+		TagLine:      tagLine,
+		GameID:       gameID,
+		QueueType:    "RANKED_TFT",
+	}
+
+	err := handler.HandleGameStarted(ctx, gameStarted)
+	require.NoError(t, err)
+
+	// Verify wager was created
+	uow := uowFactory.CreateForGuild(guildID)
+	require.NoError(t, uow.Begin(ctx))
+
+	externalRef := entities.ExternalReference{
+		System: entities.SystemTFT,
+		ID:     gameID,
+	}
+
+	wager, err := uow.GroupWagerRepository().GetByExternalReference(ctx, externalRef)
+	require.NoError(t, err)
+	require.NotNil(t, wager)
+	require.Equal(t, entities.GroupWagerStateActive, wager.State)
+	uow.Rollback()
+
+	// Game end - very short duration (would be cancelled in LoL but not in TFT)
+	gameEnded := dto.TFTGameEndedDTO{
+		SummonerName:    summonerName,
+		TagLine:         tagLine,
+		GameID:          gameID,
+		Placement:       7, // Bottom 4
+		DurationSeconds: 300, // 5 minutes - would trigger cancellation in LoL
+		QueueType:       "RANKED_TFT",
+	}
+
+	err = handler.HandleGameEnded(ctx, gameEnded)
+	require.NoError(t, err)
+
+	// Verify wager was RESOLVED, not cancelled (TFT has no 10-minute cancellation logic)
+	uow = uowFactory.CreateForGuild(guildID)
+	require.NoError(t, uow.Begin(ctx))
+	defer uow.Rollback()
+
+	wager, err = uow.GroupWagerRepository().GetByExternalReference(ctx, externalRef)
+	require.NoError(t, err)
+	require.NotNil(t, wager)
+	assert.Equal(t, entities.GroupWagerStateResolved, wager.State)
+	assert.NotNil(t, wager.WinningOptionID)
+
+	// Verify the correct option won (Bottom 4 for placement 7)
+	detail, err := uow.GroupWagerRepository().GetDetailByID(ctx, wager.ID)
+	require.NoError(t, err)
+	require.NotNil(t, detail)
+
+	var winOption *entities.GroupWagerOption
+	for _, opt := range detail.Options {
+		if opt.ID == *wager.WinningOptionID {
+			winOption = opt
+			break
+		}
+	}
+	require.NotNil(t, winOption)
+	assert.Equal(t, "Bottom 4", winOption.OptionText)
+}
+
+func TestTFTHandler_MultipleGuilds(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// Set up test config
+	config.SetTestConfig(config.NewTestConfig())
+	defer config.ResetConfig()
+
+	// Setup test database
+	testDB := testutil.SetupTestDatabase(t)
+	defer testDB.Cleanup(t)
+
+	// Create no-op event publisher for integration tests
+	noopPublisher := infrastructure.NewNoopEventPublisher()
+
+	// Create UoW factory
+	uowFactory := infrastructure.NewUnitOfWorkFactory(testDB.DB, noopPublisher)
+
+	// Setup test data
+	ctx := context.Background()
+	guild1ID := int64(11111)
+	guild2ID := int64(22222)
+	summonerName := "SharedTFTPlayer"
+	tagLine := "NA1"
+	gameID := "tft-shared-game"
+
+	// Setup multiple guilds watching the same summoner
+	setupTFTTestData(t, ctx, uowFactory, guild1ID, summonerName, tagLine)
+	setupTFTTestData(t, ctx, uowFactory, guild2ID, summonerName, tagLine)
+
+	// Create mock Discord poster
+	mockPoster := &application.MockDiscordPoster{}
+
+	// Create TFT handler
+	handler := application.NewTFTHandler(uowFactory, mockPoster)
+
+	// Game start - should create wagers for both guilds
+	gameStarted := dto.TFTGameStartedDTO{
+		SummonerName: summonerName,
+		TagLine:      tagLine,
+		GameID:       gameID,
+		QueueType:    "RANKED_TFT",
+	}
+
+	err := handler.HandleGameStarted(ctx, gameStarted)
+	require.NoError(t, err)
+
+	// Verify Discord posts were made for both guilds
+	assert.Len(t, mockPoster.Posts, 2)
+
+	// Verify both wagers exist in their respective guilds
+	externalRef := entities.ExternalReference{
+		System: entities.SystemTFT,
+		ID:     gameID,
+	}
+
+	// Check guild 1
+	uow1 := uowFactory.CreateForGuild(guild1ID)
+	require.NoError(t, uow1.Begin(ctx))
+	defer uow1.Rollback()
+
+	wager1, err := uow1.GroupWagerRepository().GetByExternalReference(ctx, externalRef)
+	require.NoError(t, err)
+	require.NotNil(t, wager1)
+	assert.Equal(t, guild1ID, wager1.GuildID)
+
+	// Check guild 2
+	uow2 := uowFactory.CreateForGuild(guild2ID)
+	require.NoError(t, uow2.Begin(ctx))
+	defer uow2.Rollback()
+
+	wager2, err := uow2.GroupWagerRepository().GetByExternalReference(ctx, externalRef)
+	require.NoError(t, err)
+	require.NotNil(t, wager2)
+	assert.Equal(t, guild2ID, wager2.GuildID)
+
+	// Game end - should resolve both wagers
+	gameEnded := dto.TFTGameEndedDTO{
+		SummonerName:    summonerName,
+		TagLine:         tagLine,
+		GameID:          gameID,
+		Placement:       2, // Top 4
+		DurationSeconds: 1500,
+		QueueType:       "RANKED_TFT",
+	}
+
+	err = handler.HandleGameEnded(ctx, gameEnded)
+	require.NoError(t, err)
+
+	// Verify both wagers are resolved
+	wager1, err = uow1.GroupWagerRepository().GetByExternalReference(ctx, externalRef)
+	require.NoError(t, err)
+	assert.Equal(t, entities.GroupWagerStateResolved, wager1.State)
+
+	wager2, err = uow2.GroupWagerRepository().GetByExternalReference(ctx, externalRef)
+	require.NoError(t, err)
+	assert.Equal(t, entities.GroupWagerStateResolved, wager2.State)
+}
+
+func TestTFTHandler_NoWatchingGuilds(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// Set up test config
+	config.SetTestConfig(config.NewTestConfig())
+	defer config.ResetConfig()
+
+	// Setup test database
+	testDB := testutil.SetupTestDatabase(t)
+	defer testDB.Cleanup(t)
+
+	// Create no-op event publisher for integration tests
+	noopPublisher := infrastructure.NewNoopEventPublisher()
+
+	// Create UoW factory
+	uowFactory := infrastructure.NewUnitOfWorkFactory(testDB.DB, noopPublisher)
+
+	ctx := context.Background()
+
+	mockPoster := &application.MockDiscordPoster{}
+	handler := application.NewTFTHandler(uowFactory, mockPoster)
+
+	// Game start for unwatched summoner
+	gameStarted := dto.TFTGameStartedDTO{
+		SummonerName: "UnwatchedTFTPlayer",
+		TagLine:      "NA1",
+		GameID:       "tft-unwatched-game",
+		QueueType:    "RANKED_TFT",
+	}
+
+	err := handler.HandleGameStarted(ctx, gameStarted)
+	require.NoError(t, err)
+
+	// No Discord posts should be made
+	assert.Len(t, mockPoster.Posts, 0)
+
+	// Game end should also handle gracefully
+	gameEnded := dto.TFTGameEndedDTO{
+		SummonerName:    "UnwatchedTFTPlayer",
+		TagLine:         "NA1",
+		GameID:          "tft-unwatched-game",
+		Placement:       1,
+		DurationSeconds: 1800,
+		QueueType:       "RANKED_TFT",
+	}
+
+	err = handler.HandleGameEnded(ctx, gameEnded)
+	require.NoError(t, err)
+}
+
+func TestTFTHandler_MissingTFTChannel(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// Set up test config
+	config.SetTestConfig(config.NewTestConfig())
+	defer config.ResetConfig()
+
+	// Setup test database
+	testDB := testutil.SetupTestDatabase(t)
+	defer testDB.Cleanup(t)
+
+	// Create no-op event publisher for integration tests
+	noopPublisher := infrastructure.NewNoopEventPublisher()
+
+	// Create UoW factory
+	uowFactory := infrastructure.NewUnitOfWorkFactory(testDB.DB, noopPublisher)
+
+	// Setup test data
+	ctx := context.Background()
+	guildID := int64(99999)
+	summonerName := "NoChannelPlayer"
+	tagLine := "NA1"
+	gameID := "tft-no-channel-game"
+
+	// Setup guild without TFT channel
+	setupTFTTestDataWithoutChannel(t, ctx, uowFactory, guildID, summonerName, tagLine)
+
+	// Create mock Discord poster
+	mockPoster := &application.MockDiscordPoster{}
+
+	// Create TFT handler
+	handler := application.NewTFTHandler(uowFactory, mockPoster)
+
+	// Game start - should not create wager due to missing TFT channel
+	gameStarted := dto.TFTGameStartedDTO{
+		SummonerName: summonerName,
+		TagLine:      tagLine,
+		GameID:       gameID,
+		QueueType:    "RANKED_TFT",
+	}
+
+	err := handler.HandleGameStarted(ctx, gameStarted)
+	require.NoError(t, err) // Handler should not error, just skip the guild
+
+	// No Discord posts should be made
+	assert.Len(t, mockPoster.Posts, 0)
+
+	// Verify no wager was created
+	uow := uowFactory.CreateForGuild(guildID)
+	require.NoError(t, uow.Begin(ctx))
+	defer uow.Rollback()
+
+	externalRef := entities.ExternalReference{
+		System: entities.SystemTFT,
+		ID:     gameID,
+	}
+
+	wager, err := uow.GroupWagerRepository().GetByExternalReference(ctx, externalRef)
+	require.NoError(t, err)
+	assert.Nil(t, wager) // No wager should exist
+}
+
+// setupTFTTestData creates the necessary guild settings and summoner watch for TFT testing
+func setupTFTTestData(t *testing.T, ctx context.Context, uowFactory application.UnitOfWorkFactory, guildID int64, summonerName, tagLine string) {
+	uow := uowFactory.CreateForGuild(guildID)
+	require.NoError(t, uow.Begin(ctx))
+	defer func() {
+		if err := uow.Commit(); err != nil {
+			t.Fatalf("Failed to commit test data setup: %v", err)
+		}
+	}()
+
+	// Create guild settings with TFT channel
+	guildSettings := &entities.GuildSettings{
+		GuildID:      guildID,
+		TftChannelID: func() *int64 { id := int64(888888); return &id }(), // Mock TFT channel ID
+	}
+
+	_, err := uow.GuildSettingsRepository().GetOrCreateGuildSettings(ctx, guildID)
+	require.NoError(t, err)
+
+	// Update with TFT channel
+	err = uow.GuildSettingsRepository().UpdateGuildSettings(ctx, guildSettings)
+	require.NoError(t, err)
+
+	// Create summoner watch
+	_, err = uow.SummonerWatchRepository().CreateWatch(ctx, guildID, summonerName, tagLine)
+	require.NoError(t, err)
+}
+
+// setupTFTTestDataWithoutChannel creates guild settings without TFT channel for negative testing
+func setupTFTTestDataWithoutChannel(t *testing.T, ctx context.Context, uowFactory application.UnitOfWorkFactory, guildID int64, summonerName, tagLine string) {
+	uow := uowFactory.CreateForGuild(guildID)
+	require.NoError(t, uow.Begin(ctx))
+	defer func() {
+		if err := uow.Commit(); err != nil {
+			t.Fatalf("Failed to commit test data setup: %v", err)
+		}
+	}()
+
+	// Create guild settings WITHOUT TFT channel
+	guildSettings := &entities.GuildSettings{
+		GuildID:      guildID,
+		TftChannelID: nil, // No TFT channel configured
+	}
+
+	_, err := uow.GuildSettingsRepository().GetOrCreateGuildSettings(ctx, guildID)
+	require.NoError(t, err)
+
+	// Update without TFT channel
+	err = uow.GuildSettingsRepository().UpdateGuildSettings(ctx, guildSettings)
+	require.NoError(t, err)
+
+	// Create summoner watch
+	_, err = uow.SummonerWatchRepository().CreateWatch(ctx, guildID, summonerName, tagLine)
+	require.NoError(t, err)
+}

--- a/discord-client/bot/commands.go
+++ b/discord-client/bot/commands.go
@@ -190,6 +190,19 @@ func (b *Bot) registerCommands() error {
 				},
 				{
 					Type:        discordgo.ApplicationCommandOptionSubCommand,
+					Name:        "tft-channel",
+					Description: "Set the channel for Teamfight Tactics activities",
+					Options: []*discordgo.ApplicationCommandOption{
+						{
+							Type:        discordgo.ApplicationCommandOptionChannel,
+							Name:        "channel",
+							Description: "The channel to set for TFT activities (leave empty to disable)",
+							Required:    false,
+						},
+					},
+				},
+				{
+					Type:        discordgo.ApplicationCommandOptionSubCommand,
 					Name:        "wordle-channel",
 					Description: "Set the channel for Wordle results and rewards",
 					Options: []*discordgo.ApplicationCommandOption{

--- a/discord-client/bot/features/settings/feature.go
+++ b/discord-client/bot/features/settings/feature.go
@@ -34,6 +34,8 @@ func (f *Feature) HandleCommand(s *discordgo.Session, i *discordgo.InteractionCr
 		f.handlePrimaryChannel(s, i)
 	case "lol-channel":
 		f.handleLolChannel(s, i)
+	case "tft-channel":
+		f.handleTftChannel(s, i)
 	case "wordle-channel":
 		f.handleWordleChannel(s, i)
 	}

--- a/discord-client/bot/features/settings/handler.go
+++ b/discord-client/bot/features/settings/handler.go
@@ -267,6 +267,91 @@ func (f *Feature) handleLolChannel(s *discordgo.Session, i *discordgo.Interactio
 	}
 }
 
+// handleTftChannel handles the /settings tft-channel command
+func (f *Feature) handleTftChannel(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	// Check if user has admin permissions
+	if !common.IsUserAdmin(s, i.GuildID, i.Member.User.ID) {
+		common.RespondWithError(s, i, "❌ You need administrator permissions to use this command")
+		return
+	}
+
+	// Parse guild ID
+	guildID, err := strconv.ParseInt(i.GuildID, 10, 64)
+	if err != nil {
+		log.Errorf("Failed to parse guild ID: %v", err)
+		common.RespondWithError(s, i, "❌ Failed to process command")
+		return
+	}
+
+	// Get the channel option (if provided)
+	options := i.ApplicationCommandData().Options[0].Options
+	var channelID *int64
+
+	if len(options) > 0 && options[0].Name == "channel" {
+		// User provided a channel
+		channelIDStr := options[0].ChannelValue(s).ID
+		if channelIDStr != "" {
+			channelIDInt, err := strconv.ParseInt(channelIDStr, 10, 64)
+			if err != nil {
+				log.Errorf("Failed to parse channel ID: %v", err)
+				common.RespondWithError(s, i, "❌ Invalid channel selected")
+				return
+			}
+			channelID = &channelIDInt
+		}
+	}
+
+	ctx := context.Background()
+
+	// Create guild-scoped unit of work
+	uow := f.uowFactory.CreateForGuild(guildID)
+	if err := uow.Begin(ctx); err != nil {
+		log.Errorf("Error beginning transaction: %v", err)
+		common.RespondWithError(s, i, "❌ Failed to update settings")
+		return
+	}
+	defer uow.Rollback()
+
+	// Instantiate guild settings service with repositories from UnitOfWork
+	guildSettingsService := services.NewGuildSettingsService(
+		uow.GuildSettingsRepository(),
+	)
+
+	// Update the TFT channel setting
+	if err := guildSettingsService.UpdateTftChannel(ctx, guildID, channelID); err != nil {
+		log.Errorf("Failed to update TFT channel: %v", err)
+		common.RespondWithError(s, i, "❌ Failed to update settings")
+		return
+	}
+
+	// Commit the transaction
+	if err := uow.Commit(); err != nil {
+		log.Errorf("Error committing transaction: %v", err)
+		common.RespondWithError(s, i, "❌ Failed to update settings")
+		return
+	}
+
+	// Respond with success
+	var message string
+	if channelID != nil {
+		message = fmt.Sprintf("✅ TFT channel updated to <#%d>", *channelID)
+	} else {
+		message = "✅ TFT channel feature disabled"
+	}
+
+	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: message,
+			Flags:   discordgo.MessageFlagsEphemeral,
+		},
+	})
+
+	if err != nil {
+		log.Errorf("Failed to respond to interaction: %v", err)
+	}
+}
+
 // handleWordleChannel handles the /settings wordle-channel command
 func (f *Feature) handleWordleChannel(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	// Check if user has admin permissions

--- a/discord-client/database/migrations/022_add_tft_channel_id.down.sql
+++ b/discord-client/database/migrations/022_add_tft_channel_id.down.sql
@@ -1,0 +1,2 @@
+-- Remove tft_channel_id from guild_settings table
+ALTER TABLE guild_settings DROP COLUMN tft_channel_id;

--- a/discord-client/database/migrations/022_add_tft_channel_id.up.sql
+++ b/discord-client/database/migrations/022_add_tft_channel_id.up.sql
@@ -1,0 +1,2 @@
+-- Add tft_channel_id to guild_settings table
+ALTER TABLE guild_settings ADD COLUMN tft_channel_id BIGINT;

--- a/discord-client/domain/entities/guild_settings.go
+++ b/discord-client/domain/entities/guild_settings.go
@@ -5,6 +5,7 @@ type GuildSettings struct {
 	GuildID          int64  `db:"guild_id"`
 	PrimaryChannelID *int64 `db:"primary_channel_id"` // Nullable - channel for gamba updates
 	LolChannelID     *int64 `db:"lol_channel_id"`     // Nullable - channel for LOL updates
+	TftChannelID     *int64 `db:"tft_channel_id"`     // Nullable - channel for TFT updates
 	WordleChannelID  *int64 `db:"wordle_channel_id"`  // Nullable - channel for Wordle results
 	HighRollerRoleID *int64 `db:"high_roller_role_id"` // Nullable - role ID for high roller (NULL = disabled)
 }
@@ -17,6 +18,11 @@ func (gs *GuildSettings) HasPrimaryChannel() bool {
 // HasLolChannel checks if a LOL channel is configured
 func (gs *GuildSettings) HasLolChannel() bool {
 	return gs.LolChannelID != nil && *gs.LolChannelID > 0
+}
+
+// HasTftChannel checks if a TFT channel is configured
+func (gs *GuildSettings) HasTftChannel() bool {
+	return gs.TftChannelID != nil && *gs.TftChannelID > 0
 }
 
 // HasWordleChannel checks if a Wordle channel is configured
@@ -37,6 +43,11 @@ func (gs *GuildSettings) SetPrimaryChannel(channelID *int64) {
 // SetLolChannel sets the LOL channel ID
 func (gs *GuildSettings) SetLolChannel(channelID *int64) {
 	gs.LolChannelID = channelID
+}
+
+// SetTftChannel sets the TFT channel ID
+func (gs *GuildSettings) SetTftChannel(channelID *int64) {
+	gs.TftChannelID = channelID
 }
 
 // SetWordleChannel sets the Wordle channel ID

--- a/discord-client/domain/interfaces/services.go
+++ b/discord-client/domain/interfaces/services.go
@@ -107,6 +107,9 @@ type GuildSettingsService interface {
 	// UpdateLolChannel updates the LOL channel for a guild
 	UpdateLolChannel(ctx context.Context, guildID int64, channelID *int64) error
 
+	// UpdateTftChannel updates the TFT channel for a guild
+	UpdateTftChannel(ctx context.Context, guildID int64, channelID *int64) error
+
 	// UpdateWordleChannel updates the Wordle channel for a guild
 	UpdateWordleChannel(ctx context.Context, guildID int64, channelID *int64) error
 

--- a/discord-client/domain/services/guild_settings_service.go
+++ b/discord-client/domain/services/guild_settings_service.go
@@ -72,6 +72,26 @@ func (s *guildSettingsService) UpdateLolChannel(ctx context.Context, guildID int
 	return nil
 }
 
+// UpdateTftChannel updates the TFT channel for a guild
+func (s *guildSettingsService) UpdateTftChannel(ctx context.Context, guildID int64, channelID *int64) error {
+
+	// Get existing settings
+	settings, err := s.guildSettingsRepo.GetOrCreateGuildSettings(ctx, guildID)
+	if err != nil {
+		return fmt.Errorf("failed to get guild settings: %w", err)
+	}
+
+	// Update TFT channel (can be nil to disable)
+	settings.TftChannelID = channelID
+
+	// Save updated settings
+	if err := s.guildSettingsRepo.UpdateGuildSettings(ctx, settings); err != nil {
+		return fmt.Errorf("failed to update guild settings: %w", err)
+	}
+
+	return nil
+}
+
 // UpdateHighRollerRole updates the high roller role for a guild
 func (s *guildSettingsService) UpdateHighRollerRole(ctx context.Context, guildID int64, roleID *int64) error {
 

--- a/discord-client/infrastructure/nats_client.go
+++ b/discord-client/infrastructure/nats_client.go
@@ -184,7 +184,7 @@ func (c *NATSClient) ensureStream(streamName string, subjects []string) error {
 		MaxMsgs:     1000000,
 		Storage:     nats.FileStorage,
 		Replicas:    1,
-		Description: "League of Legends game state events",
+		Description: fmt.Sprintf("%s game state events", streamName),
 	}
 
 	// Create the stream
@@ -204,6 +204,12 @@ func (c *NATSClient) ensureStream(streamName string, subjects []string) error {
 // This should be called after connection is established
 func (c *NATSClient) EnsureLoLEventStream() error {
 	return c.ensureStream("lol_events", []string{"lol.gamestate.*"})
+}
+
+// EnsureTFTEventStream ensures the tft_events stream exists
+// This should be called after connection is established
+func (c *NATSClient) EnsureTFTEventStream() error {
+	return c.ensureStream("tft_events", []string{"tft.gamestate.*"})
 }
 
 // Publish publishes a message to the specified subject using JetStream

--- a/discord-client/infrastructure/protobuf_tft_adapter.go
+++ b/discord-client/infrastructure/protobuf_tft_adapter.go
@@ -1,0 +1,85 @@
+package infrastructure
+
+import (
+	"fmt"
+	"gambler/discord-client/application/dto"
+	events "gambler/discord-client/proto/events"
+)
+
+// ProtobufToTFTAdapter converts protobuf messages to TFT domain DTOs
+// This adapter isolates protobuf dependencies from the application layer
+type ProtobufToTFTAdapter struct{}
+
+// NewProtobufToTFTAdapter creates a new protobuf to TFT adapter
+func NewProtobufToTFTAdapter() *ProtobufToTFTAdapter {
+	return &ProtobufToTFTAdapter{}
+}
+
+// queueTypeToString converts TFTQueueType enum to string
+func (a *ProtobufToTFTAdapter) queueTypeToString(queueType events.TFTQueueType) string {
+	switch queueType {
+	case events.TFTQueueType_TFT_QUEUE_TYPE_RANKED_TFT:
+		return "RANKED_TFT"
+	case events.TFTQueueType_TFT_QUEUE_TYPE_RANKED_TFT_DOUBLE_UP:
+		return "RANKED_TFT_DOUBLE_UP"
+	case events.TFTQueueType_TFT_QUEUE_TYPE_RANKED_TFT_TURBO:
+		return "RANKED_TFT_TURBO"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// ConvertGameStateChanged converts a protobuf TFTGameStateChanged event to domain DTOs
+// Returns either a TFTGameStartedDTO or TFTGameEndedDTO based on the state transition
+func (a *ProtobufToTFTAdapter) ConvertGameStateChanged(event *events.TFTGameStateChanged) (interface{}, error) {
+	switch {
+	case a.isGameStart(event):
+		return a.convertToGameStarted(event), nil
+	case a.isGameEnd(event):
+		return a.convertToGameEnded(event)
+	default:
+		return nil, fmt.Errorf("unhandled state transition: %s -> %s",
+			event.PreviousStatus, event.CurrentStatus)
+	}
+}
+
+// isGameStart checks if the event represents a game starting
+func (a *ProtobufToTFTAdapter) isGameStart(event *events.TFTGameStateChanged) bool {
+	return event.PreviousStatus == events.TFTGameStatus_TFT_GAME_STATUS_NOT_IN_GAME &&
+		event.CurrentStatus == events.TFTGameStatus_TFT_GAME_STATUS_IN_GAME
+}
+
+// isGameEnd checks if the event represents a game ending
+func (a *ProtobufToTFTAdapter) isGameEnd(event *events.TFTGameStateChanged) bool {
+	return event.PreviousStatus == events.TFTGameStatus_TFT_GAME_STATUS_IN_GAME &&
+		event.CurrentStatus == events.TFTGameStatus_TFT_GAME_STATUS_NOT_IN_GAME
+}
+
+// convertToGameStarted converts protobuf event to TFTGameStartedDTO
+func (a *ProtobufToTFTAdapter) convertToGameStarted(event *events.TFTGameStateChanged) dto.TFTGameStartedDTO {
+	return dto.TFTGameStartedDTO{
+		GameID:       event.GameId,
+		SummonerName: event.GameName,
+		TagLine:      event.TagLine,
+		QueueType:    a.queueTypeToString(event.QueueType),
+		EventTime:    event.EventTime.AsTime(),
+	}
+}
+
+// convertToGameEnded converts protobuf event to TFTGameEndedDTO
+func (a *ProtobufToTFTAdapter) convertToGameEnded(event *events.TFTGameStateChanged) (dto.TFTGameEndedDTO, error) {
+	if event.GameResult == nil {
+		return dto.TFTGameEndedDTO{}, fmt.Errorf("game ended without result data for summoner %s#%s",
+			event.GameName, event.TagLine)
+	}
+
+	return dto.TFTGameEndedDTO{
+		GameID:          event.GameId,
+		SummonerName:    event.GameName,
+		TagLine:         event.TagLine,
+		Placement:       event.GameResult.Placement,
+		DurationSeconds: event.GameResult.DurationSeconds,
+		QueueType:       a.queueTypeToString(event.QueueType),
+		EventTime:       event.EventTime.AsTime(),
+	}, nil
+}


### PR DESCRIPTION
- Add database migration for tft_channel_id column
- Extend GuildSettings entity with TFT channel support and helper methods
- Extract base house wager handler from LoL handler for code reuse
- Create TFT-specific DTOs (TFTGameStartedDTO, TFTGameEndedDTO) and protobuf messages
- Implement TFT adapter for game data transformation
- Create TFT handler with Top 4/Bottom 4 betting options (2x odds each)
- Update message consumer to handle TFT events and ensure TFT stream exists
- Add TFT channel support to guild settings service and bot commands
- Wire TFT handler into dependency injection system

Key differences from LoL:
- No 10-minute game cancellation logic
- Placement-based betting: position <= 4 wins "Top 4", position > 4 wins "Bottom 4"
- No external match URL links initially