### PR TITLE
Add base Docker image for CI/CD workflows

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -1,0 +1,46 @@
+name: Build Base Image
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'base.Dockerfile'
+      - '.github/workflows/base-image.yml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: moreshields/gamba-base
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push base image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: base.Dockerfile
+        push: true
+        tags: |
+          ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -15,6 +15,8 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/moreshields/gamba-base:latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read
@@ -35,29 +37,16 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.24.4'
-
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-
-    - name: Install protobuf compiler
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y protobuf-compiler
-
-    - name: Install protobuf tools
-      run: make -C api install-tools
+    # Go, Python, and protobuf are pre-installed in the base image
 
     - name: Generate protobuf code
       run: make proto
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        # Need to use docker driver when running in container
+        driver: docker
 
     - name: Log in to Container Registry
       if: github.event_name != 'pull_request'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/moreshields/gamba-base:latest
     strategy:
       fail-fast: false
       matrix:
@@ -30,42 +32,19 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Set up Go
-      if: matrix.test-suite.working-dir == 'discord-client'
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.24.4'
-
-    - name: Set up Python
-      if: matrix.test-suite.working-dir == 'lol-tracker'
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-
-    - name: Cache protobuf installation
+    # Go, Python, and protobuf are pre-installed in the base image
+    
+    - name: Cache generated protobuf files
+      if: matrix.test-suite.needs-protobuf
       uses: actions/cache@v4
       with:
         path: |
-          /usr/bin/protoc
-          /usr/include/google
-          /usr/lib/x86_64-linux-gnu/libprotoc*
-          /usr/lib/x86_64-linux-gnu/libprotobuf*
-          ~/go/bin/protoc-gen-go*
-        key: ${{ runner.os }}-protobuf-3.21.12
+          api/gen/
+          discord-client/proto/
+          lol-tracker/api/gen/
+        key: ${{ runner.os }}-protobuf-gen-${{ hashFiles('api/proto/**/*.proto', 'api/Makefile') }}
         restore-keys: |
-          ${{ runner.os }}-protobuf-
-
-    - name: Install protobuf compiler
-      if: matrix.test-suite.needs-protobuf
-      run: |
-        if ! command -v protoc &> /dev/null; then
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
-        fi
-
-    - name: Install protobuf tools
-      if: matrix.test-suite.needs-protobuf
-      run: make -C api install-tools
+          ${{ runner.os }}-protobuf-gen-
 
     - name: Cache Go modules
       if: matrix.test-suite.working-dir == 'discord-client'
@@ -91,7 +70,7 @@ jobs:
       if: matrix.test-suite.working-dir == 'lol-tracker'
       run: |
         if [ ! -d "venv" ]; then
-          python -m venv venv
+          python3.11 -m venv venv
         fi
         ./venv/bin/pip install --upgrade pip
 

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -1,0 +1,33 @@
+# Base image with all build dependencies
+FROM ubuntu:22.04
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    git \
+    protobuf-compiler \
+    python3.11 \
+    python3.11-venv \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Go
+ENV GO_VERSION=1.24.4
+RUN curl -L https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz | tar -xz -C /usr/local
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+# Install Go protobuf tools
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.31.0 && \
+    go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0
+ENV PATH="/root/go/bin:${PATH}"
+
+# Create working directory
+WORKDIR /workspace
+
+# Verify installations
+RUN protoc --version && \
+    go version && \
+    python3.11 --version && \
+    protoc-gen-go --version && \
+    protoc-gen-go-grpc --version


### PR DESCRIPTION
## Summary
- Creates a base Docker image with all build dependencies pre-installed to speed up CI/CD workflows
- Reduces test workflow execution time by eliminating repeated installation of protobuf and build tools
- Improves caching strategy by caching generated protobuf files instead of system binaries

## Changes
- Add `base.Dockerfile` with Go 1.24.4, Python 3.11, protobuf compiler, and protobuf Go plugins
- Add `.github/workflows/base-image.yml` to build and push base image to ghcr.io
- Update test workflow to use base image container and cache generated protobuf files
- Update docker-build-push workflow to use base image container
- Remove redundant installation steps from both workflows

## Test plan
- [ ] Base image workflow builds successfully
- [ ] Test workflow runs successfully with base image
- [ ] Docker build/push workflow runs successfully with base image
- [ ] Verify time savings in workflow execution